### PR TITLE
Provides onReady callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ var ReactZeroClipboard = react.createClass({
 
             var remover = addZeroListener("copy", el, this.handleCopy);
             this.eventRemovers.push(remover);
+            if (this.onReady) this.onReady();
         });
     },
     componentWillUnmount: function(){

--- a/index.js
+++ b/index.js
@@ -94,6 +94,8 @@ else {
 //   onCopy={(Event -> Void)}
 //   onAfterCopy={(Event -> Void)}
 //   onErrorCopy={(Error -> Void)}
+//
+//   onReady={(Event -> Void)}
 // />
 var ReactZeroClipboard = react.createClass({
     ready: function(cb){
@@ -125,7 +127,7 @@ var ReactZeroClipboard = react.createClass({
 
             var remover = addZeroListener("copy", el, this.handleCopy);
             this.eventRemovers.push(remover);
-            if (this.onReady) this.onReady();
+            if (this.props.onReady) this.props.onReady();
         });
     },
     componentWillUnmount: function(){


### PR DESCRIPTION
I needed this callback so that I could show the button if/when zeroclipboard was ready.
Concern: what if flash is not available? With an onReady event, I can show the button if/when it is confirmed to be supported.
Without the onReady event, a button is shown that may or may not work.