### PR TITLE
Fix race condition where mounting and unmounting zeroclipboard fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ var ReactZeroClipboard = react.createClass({
         // wait for ZeroClipboard to be ready, and then bind it to our element
         this.eventRemovers = [];
         this.ready(function(){
+            if (!this.isMounted()) return;
             var el = react.findDOMNode(this);
             client.clip(el);
 


### PR DESCRIPTION
The .ready() call can complete (and does in my testcase) after the
component has mounted and also unmounted, leading it to fail. This
makes sure the component is _still_ mounted before proceeding.