### PR TITLE
Wait for DOM ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "dependencies": {
+    "domready": "^1.0.8",
     "envify": "^3"
   }
 }


### PR DESCRIPTION
Hi, thank you for this nice module. It saves me a lot of time.

I had an error in `handleZeroClipLoad()`, because `new ZeroClipboard()` manipulates DOM when it is not ready. This PR fixes the error.

[![Gyazo](https://i.gyazo.com/bfd6a145d9df607a5340efb13d30934c.png)](http://gyazo.com/bfd6a145d9df607a5340efb13d30934c) 

You can reproduce it if you use local zeroclipboard, not the cdn version of it.
This code is from my project.

``` javascript
ZeroClipboard = require('zeroclipboard')
ZeroClipboard.config({ ... })
global.ZeroClipboard = ZeroClipboard
require('react-zeroclipboard')
```