### PR TITLE
ISSUE-32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 docs-bundle.js
+.idea/

--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
    text="text to copy"
    html="&lt;b>html to copy&lt;/b>"
    richText="{\\rtf1\\ansi\n{\\b rich text to copy}}"
+   swfPath="http://user_defined_cdn_path/ZeroClipboard.swf"
    getText={(Void -> String)}
    getHtml={(Void -> String)}
    getRichText={(Void -> String)}
-
    onCopy={(Event -> Void)}
    onAfterCopy={(Event -> Void)}
    onErrorCopy={(Error -> Void)}

--- a/index.js
+++ b/index.js
@@ -116,10 +116,15 @@ function findOrLoadZeroClipboard(){
     }
 }
 
+function setUserDefinedSwfPath(path){
+  globalConfig = Object.assign(globalConfig, {swfPath: path})
+}
+
 // <ReactZeroClipboard
 //   text="text to copy"
 //   html="<b>html to copy</b>"
 //   richText="{\\rtf1\\ansi\n{\\b rich text to copy}}"
+//   swfPath="http://user_defined_cdn_path/ZeroClipboard.swf"
 //   getText={(Void -> String)}
 //   getHtml={(Void -> String)}
 //   getRichText={(Void -> String)}
@@ -132,6 +137,10 @@ function findOrLoadZeroClipboard(){
 // />
 var ReactZeroClipboard = React.createClass({
     ready: function(cb){
+        if (null != this.props.swfPath) {
+          setUserDefinedSwfPath(this.props.swfPath);
+        }
+
         findOrLoadZeroClipboard();
 
         if (client) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-zeroclipboard",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "react component for zeroclipboard",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
@brigand According to the issue mentioned below, it's recommended to host the ZeroClipboard.swf separately if it's intended to be served over https. I added an option to provide a user defined swfPath in order to meet these requirements.

`
<ReactZeroClipboard swfPath="//user-defined-swf-path/ZeroClipboard.swf"></ReactZeroClipboard>
`

My company has policies in place within our private CDN which can resolve https request to http before forwarding on specific url's, allowing requested assets to be returned as expected. This isn't a use case that we run into everyday, but it's something we prepare for when dealing with third party packages. I'm not sure if other companies have the same policies in place, but this fixed our cross protocol issues with ZeroClipboard and the button is working as expected.

Ref:
https://github.com/zeroclipboard/zeroclipboard/issues/570
Docs: https://github.com/zeroclipboard/zeroclipboard/blob/master/docs/instructions.md#cross-protocol-limitations