### PR TITLE
Use create-react-class to avoid deprecation

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ReactDOM = require('react-dom');
 var ReactZeroClipboard = require('./');
 window.d = ReactDOM;
@@ -7,7 +8,7 @@ var zclipProps = {
   swfPath: './assets/ZeroClipboard.swf'
 };
 
-NpmInstallLink = React.createClass({
+NpmInstallLink = createReactClass({
     render: function(){
         return (
         <div className="input-group">
@@ -27,7 +28,7 @@ var list = [
     "apples", "oranges", "bananas"
 ];
 
-var MultiTypeDemo = React.createClass({
+var MultiTypeDemo = createReactClass({
     getText: function(){
         return list.map(function(x){ return "- " + x }).join("\n");
     },
@@ -66,7 +67,7 @@ var MultiTypeDemo = React.createClass({
 
 ReactDOM.render(<MultiTypeDemo />, document.getElementById("list-demo-target"));
 
-var EventsDemo = React.createClass({
+var EventsDemo = createReactClass({
     getInitialState: function(){
         return {
             logs: [],

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ReactDOM = require('react-dom');
 var loadScript = require('./loadScript');
 var ZeroClipboard, client;
@@ -135,7 +136,7 @@ function setUserDefinedSwfPath(path){
 //
 //   onReady={(Event -> Void)}
 // />
-var ReactZeroClipboard = React.createClass({
+var ReactZeroClipboard = createReactClass({
     ready: function(cb){
         if (null != this.props.swfPath) {
           setUserDefinedSwfPath(this.props.swfPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-zeroclipboard",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "react component for zeroclipboard",
   "main": "index.js",
   "keywords": [
@@ -32,6 +32,7 @@
     ]
   },
   "dependencies": {
+    "create-react-class": "^15.5.3",
     "envify": "^3"
   }
 }


### PR DESCRIPTION
I was getting the "React.createClass is deprecated" error because zeroclipboard is still using it. This fixes that warning.